### PR TITLE
feat: 디자이너 리스트 출력 및 30분 이내 예약 내역 노출 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.13",
         "json-server": "^1.0.0-beta.3",
         "lucide-react": "^0.475.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.13",
     "json-server": "^1.0.0-beta.3",
     "lucide-react": "^0.475.0",
     "react": "^18.2.0",

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -5,15 +5,29 @@ export const localURL = "http://localhost:3001";
 
 interface ReservationEndpoint {
   list: string;
+  get_list: string;
 }
 
 interface LocalEndpoint {
   designers: string;
 }
 
+/**
+# ======================#
+|       RESERVATION     |
+# ======================#
+*/
+
 export const RESERVATION_ENDPOINT: ReservationEndpoint = Object.freeze({
-  list: `${serverURL}/reservations/list`,
+  list: `${serverURL}/reservations/list`, // 디자이너 예약 목록 조회
+  get_list: `${serverURL}/reservations/get_list`, // 사용자 예약 내역 조회
 });
+
+/**
+# ======================#
+|         LOCAL         |
+# ======================#
+*/
 
 export const LOCAL_ENDPOINT: LocalEndpoint = Object.freeze({
   designers: `${localURL}/designers`,

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -1,11 +1,12 @@
 export const serverURL = import.meta.env.VITE_API_BASE_URL;
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 // 로컬 서버 엔드포인트
 export const localURL = "http://localhost:3001";
 
 interface ReservationEndpoint {
   list: string;
-  get_list: string;
+  get_list: (user_Id: string) => string;
 }
 
 interface LocalEndpoint {
@@ -20,7 +21,7 @@ interface LocalEndpoint {
 
 export const RESERVATION_ENDPOINT: ReservationEndpoint = Object.freeze({
   list: `${serverURL}/reservations/list`, // 디자이너 예약 목록 조회
-  get_list: `${serverURL}/reservations/get_list`, // 사용자 예약 내역 조회
+  get_list: (user_Id: string) => `${BASE_URL}/reservations/get_list?user_id=${user_Id}`, // 사용자 예약 내역 조회
 });
 
 /**

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -2,7 +2,7 @@ export const serverURL = import.meta.env.VITE_API_BASE_URL;
 export const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 // 로컬 서버 엔드포인트
-export const localURL = "http://localhost:3001";
+export const localURL = "http://localhost:3000";
 
 interface ReservationEndpoint {
   list: string;
@@ -21,7 +21,7 @@ interface LocalEndpoint {
 
 export const RESERVATION_ENDPOINT: ReservationEndpoint = Object.freeze({
   list: `${serverURL}/reservations/list`, // 디자이너 예약 목록 조회
-  get_list: (user_Id: string) => `${BASE_URL}/reservations/get_list?user_id=${user_Id}`, // 사용자 예약 내역 조회
+  get_list: (user_Id: string) => `${BASE_URL}/reservation/get_list?user_id=${user_Id}`, // 사용자 예약 내역 조회
 });
 
 /**

--- a/src/apis/reservation.ts
+++ b/src/apis/reservation.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { RESERVATION_ENDPOINT } from "./endpoints";
 
-export const getReservationList = async () => {
-  const user_id = "67ab499ba706f516fb348ddd";
+export const getReservationList = async (user_id: string) => {
   try {
     const response = await axios.get(RESERVATION_ENDPOINT.get_list(user_id));
     return response.data;

--- a/src/apis/reservation.ts
+++ b/src/apis/reservation.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { RESERVATION_ENDPOINT } from "./endpoints";
+
+export const getReservationList = async () => {
+  const user_id = "67ab499ba706f516fb348ddd";
+  try {
+    const response = await axios.get(RESERVATION_ENDPOINT.get_list(user_id));
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -2,8 +2,13 @@ const DESIGNER = {
   list: ["designerList"],
 };
 
+const RESERVATION = {
+  list: (user_id: string) => ["reservationList", { user_id }],
+};
+
 const QUERY_KEY = {
   designer: DESIGNER,
+  reservationList: RESERVATION,
 };
 
 export default QUERY_KEY;

--- a/src/pages/DesignerListPage/components/ReservationItem.tsx
+++ b/src/pages/DesignerListPage/components/ReservationItem.tsx
@@ -1,0 +1,14 @@
+import { Reservation } from "@/types/apiTypes";
+
+const ReservationItem = ({ reservationData }: { reservationData: Reservation }) => {
+  return (
+    <div>
+      <div className="w-[80%] h-[310px] bg-gray-500 rounded-md m-auto my-8 text-center">
+        {reservationData.id}
+        <p>30분 이내 예약 내역</p>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationItem;

--- a/src/pages/DesignerListPage/index.tsx
+++ b/src/pages/DesignerListPage/index.tsx
@@ -2,29 +2,63 @@ import { getDesignerList } from "@/apis/designerList";
 import QUERY_KEY from "@/constants/queryKey";
 import { useQuery } from "@tanstack/react-query";
 import DesignerList from "./components/DesignerList";
-import Footer from "@/components/common/Footer";
+import { getReservationList } from "@/apis/reservation";
+import { useMemo } from "react";
+import { Reservation } from "@/types/apiTypes";
+import dayjs from "dayjs";
+import ReservationItem from "./components/ReservationItem";
+import { formatDate } from "@/utils/dayFormat";
 
 const DesignerListPage = () => {
-	const { data, isPending } = useQuery({
-		queryKey: QUERY_KEY.designer.list,
-		queryFn: getDesignerList,
-	})
-	
-	return (
-		<>
-			<div>
-			{isPending ? (
-				<div>Loading...</div>
-			) : (
-				<div className="w-full p-1">
-					<DesignerList designers={data}/>
-				</div>
-			)}
+  const { data: designerData, isPending: designerPending } = useQuery({
+    queryKey: QUERY_KEY.designer.list,
+    queryFn: getDesignerList,
+  });
 
-				<Footer />
-			</div>
-		</>
-	);
+  const user_id = "67ab499ba706f516fb348ddd";
+
+  const { data: reservationsData, isPending: reservationPending } = useQuery({
+    queryKey: QUERY_KEY.reservationList.list(user_id),
+    queryFn: () => getReservationList(user_id),
+  });
+
+  const upcomingReservations = useMemo(() => {
+    if (!reservationsData) return [];
+
+    const now = dayjs("2025-04-20 12:01");
+
+    const thirtyMinutesLater = now.add(30, "minute");
+
+    return reservationsData.filter((reservation: Reservation) => {
+      const reservationTime = formatDate(reservation.reservation_date_time);
+
+      return (
+        reservation.status !== "예약취소" && // 취소된 예약 제외
+        reservationTime.isAfter(now) && // 현재 시간 이후
+        reservationTime.isBefore(thirtyMinutesLater) // 30분 이내
+      );
+    });
+  }, [reservationsData]);
+
+  return (
+    <>
+      {reservationPending && <div>Loading...</div>}
+      {upcomingReservations.length === 0 && <div>30분 이내 예약 없음</div>}
+      {upcomingReservations.length > 0 && (
+        <ReservationItem reservationData={upcomingReservations[0]}></ReservationItem>
+      )}
+
+      <div>
+        {designerPending ? (
+          <div>Loading...</div>
+        ) : (
+          <div className="w-full p-1">
+            <DesignerList designers={designerData} />
+          </div>
+        )}
+      </div>
+    </>
+  );
 };
 
 export default DesignerListPage;

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -12,3 +12,13 @@ export interface Designer {
   non_face_consulting_fee: number;
   updated_at: string;
 }
+
+export interface Reservation {
+  id: string;
+  designer_id: string;
+  user_id: string;
+  consulting_fee: number;
+  mode: "대면" | "비대면";
+  reservation_date_time: string;
+  status: "예약완료" | "예약취소" | "상담완료";
+}

--- a/src/utils/dayFormat.js
+++ b/src/utils/dayFormat.js
@@ -1,0 +1,13 @@
+import dayjs from "dayjs";
+
+// "202509221030" 형식을 dayjs 객체로 변환
+export const reservationTime = (date) => {
+  const formattedData = dayjs(
+    `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)} ${date.slice(8, 10)}:${date.slice(
+      10,
+      12
+    )}`
+  );
+
+  return formattedData;
+};

--- a/src/utils/dayFormat.ts
+++ b/src/utils/dayFormat.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 
 // "202509221030" 형식을 dayjs 객체로 변환
-export const reservationTime = (date) => {
+export const formatDate = (date: string) => {
   const formattedData = dayjs(
     `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)} ${date.slice(8, 10)}:${date.slice(
       10,


### PR DESCRIPTION
(#16 )

- 디자이너 예약 리스트 API 엔드포인트 구현
- 예약 관련 타입 정의 및 쿼리 키 설정
- day.js를 활용한 날짜 포맷팅 유틸 추가
- 디자이너 리스트 및 30분 이내 예약 내역 노출 구현
